### PR TITLE
fix: fix warning for setup.cfg in humble

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 [develop]
-script-dir=$base/lib/audio_driver
+script_dir=$base/lib/audio_driver
 [install]
-install-scripts=$base/lib/audio_driver
+install_scripts=$base/lib/audio_driver


### PR DESCRIPTION
## Description

Humble環境でビルドする時に出力される、PythonライブラリのWarningを解消します。

colcon内部で呼び出されるsetuptoolsのバージョンアップにより、setup.cfgで使われる設定値の名前のセパレータは"-"ではなく"_"を使うべきとのWarningが追加されました。setup.cfgの該当箇所を修正し、Warningが出力されないようにします。

<!-- Write a brief description of this PR. -->

## Related links

* Jira ticket
    * [Ticket (COMPANY INTERNAL LINK)]

[Ticket (COMPANY INTERNAL LINK)]: https://tier4.atlassian.net/browse/AEAP-523

[ament_cmake issue:382]: https://github.com/ament/ament_cmake/issues/382
[colcon issue:454]: https://github.com/colcon/colcon-core/issues/454

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

colconのビルドが正常に完了し、以下のWarningが出力されないこと。

```sh
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
  warnings.warn(
```

以下のWarningについては、ament_cmake, colconのIssue([ament_cmake issue:382], [colcon issue:454])にて結論が出ていないことから、修正を見送っております。

```sh
/usr/lib/python3/dist-packages/setuptools/command/easy_install.py:158: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
```

修正により、install/audio_driverの配下にコピーされるファイルの違いがないことも確認済です。
修正前後でどちらも以下の出力となります。

<details><summary>install/audio_driverに対するtreeコマンドのログ。</summary>
<p>

```sh
se-osaka-dev34@c4f71e2738dd:~/autoware/install/audio_driver$ tree
.
|-- lib
|   |-- audio_driver
|   |   `-- audio_driver
|   `-- python3.10
|       `-- site-packages
|           `-- audio-driver.egg-link
`-- share
    |-- ament_index
    |   `-- resource_index
    |       `-- packages
    |           `-- audio_driver
    |-- audio_driver
    |   |-- hook
    |   |   |-- ament_prefix_path.dsv
    |   |   |-- ament_prefix_path.ps1
    |   |   |-- ament_prefix_path.sh
    |   |   |-- pythonpath.dsv
    |   |   |-- pythonpath.ps1
    |   |   `-- pythonpath.sh
    |   |-- launch
    |   |   `-- audio_driver.launch.xml
    |   |-- package.bash
    |   |-- package.dsv
    |   |-- package.ps1
    |   |-- package.sh
    |   |-- package.xml
    |   `-- package.zsh
    `-- colcon-core
        `-- packages
            `-- audio_driver

13 directories, 17 files
```

</p>
</details>

## Notes for reviewers

None.

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
